### PR TITLE
fix: #19 by using primary color for foreground

### DIFF
--- a/BackupStatusWidget/BackupDiskStatusWidgetView.swift
+++ b/BackupStatusWidget/BackupDiskStatusWidgetView.swift
@@ -106,6 +106,7 @@ struct BackupDiskStatusWidgetView: View {
             }
         }
         .fontDesign(.monospaced)
+        .foregroundStyle(.primary)
         .frame(maxWidth: .infinity)
     }
     


### PR DESCRIPTION
### What changed

This PR fixes issue #19 by forcing foreground element style to primary color. This fixes the contrast issue when user is using liquid glass supported os. 

<img width="170" height="174" alt="Screenshot 2025-12-25 at 11 57 01 PM" src="https://github.com/user-attachments/assets/78f52267-ae5e-48f1-b0ac-a2b3cae37281" />
