### PR TITLE
Fix widget text invisible due to low-contrast background

### DIFF
--- a/BackupStatusWidget/BackupDiskStatusWidget.swift
+++ b/BackupStatusWidget/BackupDiskStatusWidget.swift
@@ -54,7 +54,7 @@ struct BackupDiskStatusWidget: Widget {
     var body: some WidgetConfiguration {
         AppIntentConfiguration(kind: .widgetKind, intent: BackupDiskStatusWidgetIntent.self, provider: Provider()) { entry in
             BackupDiskStatusWidgetEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
+                .containerBackground(.fill, for: .widget)
         }
         .configurationDisplayName("Backup Disk Status")
         .description("View when Time Machine made backups to a selected backup Disk.")

--- a/BackupStatusWidget/BackupDiskStatusWidgetView.swift
+++ b/BackupStatusWidget/BackupDiskStatusWidgetView.swift
@@ -176,7 +176,7 @@ struct BackupDiskStatusWidgetView: View {
                 }
                 .frame(width: 345, height: 345)
             }
-            .background(.white)
+            .background(Color(nsColor: .windowBackgroundColor))
             .cornerRadius(25)
         }
         .padding()
@@ -203,7 +203,7 @@ struct BackupDiskStatusWidgetView: View {
                 }
                 .frame(width: 345, height: 345)
             }
-            .background(.white)
+            .background(Color(nsColor: .windowBackgroundColor))
             .cornerRadius(25)
         }
         .padding()


### PR DESCRIPTION
## Summary
- Changed `.containerBackground(.fill.tertiary, for: .widget)` to `.containerBackground(.fill, for: .widget)` — the `.tertiary` modifier made the background nearly white/transparent in fullColor rendering mode, causing white-on-white invisible text
- Updated preview backgrounds from hardcoded `.white` to `Color(nsColor: .windowBackgroundColor)` for light/dark mode adaptiveness

<div align="center">
  <table>
    <tr>
      <td align="center">
        Before
      </td>
      <td align="center">
        After
      </td>
    </tr>
    <tr>
      <td align="center">
<img width="394" height="374" alt="CleanShot 2026-04-11 at 09 16 56" src="https://github.com/user-attachments/assets/d8626173-a4ee-4987-a349-b1af20c37368" />
      </td>
      <td align="center">
<img width="377" height="375" alt="CleanShot 2026-04-11 at 09 45 51" src="https://github.com/user-attachments/assets/0d2c8521-0b62-4733-b7e3-a1db6eb55ba0" />
      </td>
    </tr>
  </table>
</div>

## Root cause
`.fill.tertiary` resolves to a very light, nearly transparent background in `.fullColor` rendering mode (Notification Center). The existing semantic text colors (`.primary`, `.secondary`, `.tertiary`) are designed to contrast against `.fill`, not `.fill.tertiary`. Dropping the `.tertiary` modifier gives the system a proper opaque background that works across all widget rendering modes (vibrant, fullColor, accented).

## Test plan
- [ ] Build & run widget in Notification Center in both light and dark macOS appearance — text should be legible
- [ ] Place widget on desktop with various wallpapers — system compositing should maintain legibility
- [ ] Verify Xcode previews render with appropriate light/dark backgrounds